### PR TITLE
autoloader updates + default lan allow rule (#8)

### DIFF
--- a/dnx_configure/dnx_autoloader.py
+++ b/dnx_configure/dnx_autoloader.py
@@ -29,11 +29,11 @@ VERBOSE = False
 
 def sprint(string):
     '''setup print. includes timestamp before arg str.'''
-    print(f'{time.strftime('%H:%M:%S')}| {string}')
+    print(f'{time.strftime("%H:%M:%S")}| {string}')
 
 def eprint(string):
     '''error print. includes timestamp and alert before arg str.'''
-    print(f'{time.strftime('%H:%M:%S')}| !!! {string}')
+    print(f'{time.strftime("%H:%M:%S")}| !!! {string}')
 
     os._exit(1)
 
@@ -222,7 +222,9 @@ def confirm_interfaces(interface_config):
 def install_packages():
 
     commands = [
-        ('sudo apt install python3-pip -y', 'installing python3 package installer'),
+        ('sudo apt install python3.8 python3-pip -y', 'setting up python3'),
+        ('sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 0', None),
+        ('sudo update-alternatives --set python3 /usr/bin/python3.8', None),
         ('pip3 install flask uwsgi', 'installing python web app framework'),
         ('sudo apt install nginx -y', 'installing web server driver'),
         ('sudo apt install libnetfilter-queue-dev net-tools -y', 'installing networking components'),

--- a/dnx_configure/dnx_iptables.py
+++ b/dnx_configure/dnx_iptables.py
@@ -125,6 +125,10 @@ class _Defaults:
         # NOTE: LAN INTERFACE FIREWALL
         run(f'iptables -A FORWARD -i {self._lan_int} -m mark --mark {SEND_TO_FIREWALL} -j LAN_INTERFACE', shell=True)
 
+        # IMPORTANT: default allow any outbound. this is to make the firewall plug and play for non power users. source
+        # ip network is hardcoded, but may change at a later date abd the setup does not allow user to change this value.
+        run(f'iptables -A LAN_INTERFACE -s 192.168.83.0/24 -d 0.0.0.0/0 -j ACCEPT', shell=True)
+
         # ============================================
 
         # NOTE: DMZ INTERFACE FIREWALL


### PR DESCRIPTION
* added python3 setup in autoloader (for non 3.8 default systems). added default allow rule for lan > internet.

* added missing commas

* fixed f-string bug from nested quotes