### PR TITLE
semaphore based worker queues

### DIFF
--- a/dnx_control/control/ctl_action.py
+++ b/dnx_control/control/ctl_action.py
@@ -16,7 +16,7 @@ from dnx_routines.logging.log_client import Log, direct_log
 # ==================
 # CONTROL SOCKET
 # ===================
-_control_client: Socket = socket(AF_INET, SOCK_DGRAM)
+_control_client: Socket_T = socket(AF_INET, SOCK_DGRAM)
 # connect on udp is for convenience on socket send
 _control_client.connect(CONTROL_SOCKET)
 

--- a/dnx_control/control/ctl_control.py
+++ b/dnx_control/control/ctl_control.py
@@ -38,7 +38,7 @@ MODULE_PERMISSIONS = {
 #     os.remove(CONTROL_SOCKET)
 #
 # _control_service = socket(AF_UNIX, SOCK_DGRAM)
-_control_sock: Socket = socket(AF_INET, SOCK_DGRAM)
+_control_sock: Socket_T = socket(AF_INET, SOCK_DGRAM)
 # _control_sock.setsockopt(SOL_SOCKET, SO_PASSCRED, 1)
 _control_sock.bind(CONTROL_SOCKET)
 

--- a/dnx_gentools/__init__.py
+++ b/dnx_gentools/__init__.py
@@ -4,4 +4,4 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 if (TYPE_CHECKING):
-    from dnx_gentools.standard_tools import InspectionQueue_T, Structure_T, ByteContainer_T
+    from dnx_gentools.standard_tools import RequestQueue_T, InspectionQueue_T, Structure_T, ByteContainer_T

--- a/dnx_gentools/__init__.py
+++ b/dnx_gentools/__init__.py
@@ -3,10 +3,5 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-
 if (TYPE_CHECKING):
-
-    from standard_tools import structure as _structure, bytecontainer as _bytecontainer
-
-    Structure = _structure('Structure', '')
-    ByteContainer = _bytecontainer('ByteContainer', '')
+    from dnx_gentools.standard_tools import InspectionQueue_T, Structure_T, ByteContainer_T

--- a/dnx_gentools/def_constants.py
+++ b/dnx_gentools/def_constants.py
@@ -103,11 +103,15 @@ NULL_ADDR:  tuple[str, int] = ('', -1)
 INADDR_ANY: int = 0
 LOCALHOST:  int = 2130706433
 BROADCAST:  int = 4294967295
+
 # definitions for ip proxy data structures. most/least significant bit
 MSB: int = 0b11111111111110000000000000000000
 LSB: int = 0b00000000000001111111111111111111
 UINT16_MAX: int = 0b1111111111111111
 UINT32_MAX: int = 0b11111111111111111111111111111111
+
+INSPECT_PACKET: bool = True
+DONT_INSPECT_PACKET: bool = False
 
 # NFQUEUE packet actions | marking packet, so it can be matched by following rules in order of operations
 WAN_IN: int = 10  # used for limiting certain internal functions from applying to wan > inside traffic

--- a/dnx_gentools/def_constants.py
+++ b/dnx_gentools/def_constants.py
@@ -110,10 +110,11 @@ LSB: int = 0b00000000000001111111111111111111
 UINT16_MAX: int = 0b1111111111111111
 UINT32_MAX: int = 0b11111111111111111111111111111111
 
+OK: bool = True
+ERR: bool = False
 INSPECT_PACKET: bool = True
 DONT_INSPECT_PACKET: bool = False
 
-# NFQUEUE packet actions | marking packet, so it can be matched by following rules in order of operations
 WAN_IN: int = 10  # used for limiting certain internal functions from applying to wan > inside traffic
 LAN_IN: int = 11  # used for management access traffic matching
 DMZ_IN: int = 12  # used for management access traffic matching

--- a/dnx_gentools/def_enums.py
+++ b/dnx_gentools/def_enums.py
@@ -162,7 +162,7 @@ class QueueType(_IntEnum):
 class Queue(_IntEnum):
     IP_PROXY  = 1
     DNS_PROXY = 2
-    IPS_IDS   = 3
+    IDS_IPS   = 3
     CFIREWALL = 69
     CNAT      = 70
 

--- a/dnx_gentools/def_typing.py
+++ b/dnx_gentools/def_typing.py
@@ -12,11 +12,15 @@ _DISABLED = False
 if (TYPE_CHECKING and not _DISABLED):
     from typing import TypeAlias
 
-    from threading import Lock, Event
-    from ipaddress import IPv4Address as _IPv4Address, IPv4Network as _IPv4Network
-    from socket import socket as Socket
-    from select import epoll as Epoll
+    from threading import Lock as _Lock, Event as _Event
+    from socket import socket as _socket
+    from select import epoll as _epoll
     from ssl import SSLContext
+
+    Lock_T: TypeAlias = _Lock
+    Event_T: TypeAlias = _Event
+    Socket_T: TypeAlias = _socket
+    Epoll_T: TypeAlias = _epoll
 
     Address:    TypeAlias = tuple[str, int]
     IntAddress: TypeAlias = tuple[int, int]

--- a/dnx_gentools/def_typing.py
+++ b/dnx_gentools/def_typing.py
@@ -35,7 +35,7 @@ if (TYPE_CHECKING and not _DISABLED):
     # from dnx_iptools import *
     # from dnx_routines import *
 
-    from dnx_secmods import IPProxy_T, IPS_IDS_T, DNSProxy_T
+    from dnx_secmods import IPProxy_T, IDS_IPS_T, DNSProxy_T
     from dnx_secmods import ClientQuery as _ClientQuery
     from dnx_secmods import IPPPacket as _IPPPacket, IPSPacket as _IPSPacket
     from dnx_secmods import DNSPacket as _DNSPacket
@@ -45,7 +45,7 @@ if (TYPE_CHECKING and not _DISABLED):
 
     from dnx_iptools.packet_classes import NFPacket as _NFPacket
 
-    ModuleClasses: TypeAlias = Union[IPProxy_T, IPS_IDS_T, DNSProxy_T, DHCPServer_T]
+    ModuleClasses: TypeAlias = Union[IPProxy_T, IDS_IPS_T, DNSProxy_T, DHCPServer_T]
 
     ListenerCallback: TypeAlias = Callable[..., None]
     ListenerPackets:  TypeAlias = Union[_ClientRequest, _ClientQuery]

--- a/dnx_gentools/file_operations.py
+++ b/dnx_gentools/file_operations.py
@@ -610,15 +610,15 @@ class Watcher:
     def __init__(self, watch_file: str, ext: str, cfg_type: str, filepath: str, *, callback: Callable_T):
         self._watch_file = watch_file
 
-        self._ext       = ext
-        self._cfg_type  = cfg_type
+        self._ext      = ext
+        self._cfg_type = cfg_type
         self._filepath = filepath
 
         self._callback = callback
 
-        self._full_path: str = f'{HOME_DIR}/{filepath}/usr/{watch_file}.{ext}'
+        self._full_path = f'{HOME_DIR}/{filepath}/usr/{cfg_type}/{watch_file}.{ext}'
 
-        self._last_modified_time: int = 0
+        self._last_modified_time = 0
 
     def watch(self, *args) -> None:
         '''check configured file for change in set intervals.

--- a/dnx_gentools/standard_tools.py
+++ b/dnx_gentools/standard_tools.py
@@ -99,12 +99,12 @@ class ConfigurationMixinBase:
     module_class: ModuleClasses
 
     def __init__(self):
-        # calling the module's epoll handler __init__ method
-        super().__init__()
-
         self._config_setup: bool = False
 
         self._initialize = Initialize()
+
+        # calling the module's epoll handler __init__ method
+        super().__init__()
 
     def configure(self, module_class: Optional[ModuleClasses] = None) -> None:
         '''blocking until settings are loaded/initialized.

--- a/dnx_gentools/standard_tools.py
+++ b/dnx_gentools/standard_tools.py
@@ -281,7 +281,7 @@ def dnx_queue(log: LogHandler_T, name: str = None) -> Callable[[...], Any]:
         queue_add: Callable[[Any], None] = queue.append
         queue_get: Callable[[], Any] = queue.popleft
 
-        job_available: Event = threading.Event()
+        job_available: Event_T = threading.Event()
         job_wait: Callable[[Optional[float]], bool] = job_available.wait
         job_clear: Callable[[], None] = job_available.clear
         job_set: Callable[[], None] = job_available.set

--- a/dnx_gentools/standard_tools.py
+++ b/dnx_gentools/standard_tools.py
@@ -332,7 +332,7 @@ def request_queue():
 
     class _RequestQueue:
 
-        def return_ready(self) -> ClientQuery:
+        def return_ready(self) -> ListenerPackets:
             '''function generator returning requests from queue in FIFO order.
 
             calls will block if the queue is empty and will never time out.
@@ -349,7 +349,7 @@ def request_queue():
                 yield request_queue_get()
 
         # NOTE: first arg is because this gets referenced/called via an instance.
-        def insert(self, client_query: ClientQuery) -> None:
+        def insert(self, client_query: ListenerPackets) -> None:
 
             request_queue_append(client_query)
 

--- a/dnx_gentools/standard_tools.py
+++ b/dnx_gentools/standard_tools.py
@@ -21,9 +21,9 @@ if (TYPE_CHECKING):
 __all__ = (
     'looper', 'dynamic_looper',
     'ConfigurationMixinBase', 'Initialize',
-    'dnx_queue',
+    'dnx_queue', 'inspection_queue',
     'bytecontainer', 'structure',
-    'classproperty'
+    'classproperty',
 )
 
 
@@ -305,8 +305,8 @@ def dnx_queue(log: LogHandler_T, name: str = None) -> Callable[[...], Any]:
                         fast_sleep(MSEC)
 
         def add(job: Any) -> None:
-            '''adds a job to work queue, then flags event indicating a job is available.'''
-
+            '''adds a job to work queue, then flags event indicating a job is available.
+            '''
             queue_add(job)
             job_set()
 
@@ -315,7 +315,47 @@ def dnx_queue(log: LogHandler_T, name: str = None) -> Callable[[...], Any]:
 
     return decorator
 
-def structure(obj_name: str, fields: Union[list, str]) -> Structure:
+def inspection_queue():
+
+    queue = deque()
+    queue_add = queue.append
+    queue_get = queue.popleft
+
+    sem = threading.Semaphore(0)
+    notify_add = sem.release
+    wait_for_job = sem.acquire
+
+    class _InspectionQueue:
+        '''thread safe (using semaphores) packet queue to allow for more efficient packet processing by
+        the system modules.
+
+        1 worker can be used for sequential processing of packets
+        >1 worker will allow packets to be processed concurrently
+                - performance of threads will depend on ratio of holding gil to not holding gil
+        '''
+
+        def add(self, job: ProxyPackets) -> None:
+            '''place packet into inspection queue for processing.
+            '''
+            queue_add(job)
+            notify_add()
+
+        def get(self) -> ProxyPackets:
+            '''returns packet from inspection queue for processing.
+
+            blocks until a packet is available.
+            '''
+            wait_for_job()
+            job = queue_get()
+
+            return job
+
+    if (TYPE_CHECKING):
+        return _InspectionQueue
+
+    return _InspectionQueue()
+
+def structure(obj_name: str, fields: Union[list, str]):
     '''named tuple like class factory for storing int values of raw byte sections with named fields.
 
     calling len on the container will return sum of all bytes stored not amount of fields. slots are being used to
@@ -381,7 +421,7 @@ def structure(obj_name: str, fields: Union[list, str]) -> Structure:
 
             return f'{obj_name}({comma_join(_fields)})'
 
-        def __call__(self, updates: tuple[tuple[str, int]] = None) -> Structure:
+        def __call__(self, updates: tuple[tuple[str, int]] = None) -> _Structure:
             '''returns a copy of current field assignments.
 
             a dictionary can be used to insert updated values into the new container.
@@ -450,7 +490,7 @@ def structure(obj_name: str, fields: Union[list, str]) -> Structure:
 
     return _Structure()
 
-def bytecontainer(obj_name: str, field_names: Union[list, str]) -> ByteContainer:
+def bytecontainer(obj_name: str, field_names: Union[list, str]):
     '''named tuple like class factory for storing raw byte sections with named fields.
 
     calling len on the container will return the sum of all bytes stored, not the number of fields.
@@ -531,3 +571,12 @@ class classproperty:
 
     def __get__(self, owner_self, owner_class):
         return self._fget(owner_class)
+
+
+# TYPE EXPORTS
+if (TYPE_CHECKING):
+    InspectionQueue_T: TypeAlias = inspection_queue()
+    Structure_T: TypeAlias       = structure('Structure', '')
+    ByteContainer_T: TypeAlias   = bytecontainer('ByteContainer', '')
+
+    __all__.extend(['InspectionQueue_T', 'Structure_T', 'ByteContainer_T'])

--- a/dnx_iptools/cprotocol_tools/cprotocol_tools.pxd
+++ b/dnx_iptools/cprotocol_tools/cprotocol_tools.pxd
@@ -8,6 +8,15 @@ cdef extern from "netinet/in.h":
     uint32_t htonl (uint32_t __hostlong) nogil
     uint16_t htons (uint16_t __hostshort) nogil
 
+cdef extern from '<fcntl.h>':
+    enum:
+        O_CREAT
+        O_EXCL
+
+        O_RDONLY
+        O_WRONLY
+        O_RDWR
+
 cdef extern from '<arpa/inet.h>':
     ctypedef unsigned long in_addr_t
 
@@ -16,24 +25,19 @@ cdef extern from '<arpa/inet.h>':
 
     in_addr_t inet_addr(char *cp)
 
-cdef extern from '<sys/ipc.h>':
-    enum:
-        IPC_CREAT   # Create entry if key does not exist.
-        IPC_EXCL    # Fail if key exists.
-        IPC_NOWAIT  # Error if request must wait.
+ctypedef int mode_t
 
-        IPC_PRIVATE # Private key.
+cdef extern from '<mqueue.h>':
+    ctypedef void* mqd_t
 
-        IPC_RMID    # Remove identifier.
-        IPC_SET     # Set options.
-        IPC_STAT    # Get options.
+    struct mq_attr:
+        long int mq_flags
+        long int mq_maxmsg
+        long int mq_msgsize
+        long int mq_curmsgs
 
-    ctypedef short int key_t
-
-    key_t  ftok(const char*, int)
-
-cdef extern from '<sys/msg.h>':
-    int       msgctl(int a, int b, void* c)
-    int       msgget(key_t a, int b)
-    ssize_t   msgrcv(int a, void* b, size_t c, long int d, int e)
-    int       msgsnd(int a, const void* b, size_t c, int d)
+    mqd_t   mq_open(const char *name, int oflag, mode_t mode, mq_attr *attr)
+    int     mq_close(mqd_t mqdes)
+    int     mq_send(mqd_t mqdes, const char *msg_ptr, size_t msg_len, unsigned int msg_prio)
+    ssize_t mq_receive(mqd_t mqdes, char *msg_ptr, size_t msg_len, unsigned int *msg_prio)
+    int     mq_unlink(const char *name)

--- a/dnx_iptools/cprotocol_tools/cprotocol_tools.pxd
+++ b/dnx_iptools/cprotocol_tools/cprotocol_tools.pxd
@@ -15,3 +15,25 @@ cdef extern from '<arpa/inet.h>':
         pass
 
     in_addr_t inet_addr(char *cp)
+
+cdef extern from '<sys/msg.h>':
+    int       msgctl(int, int, void*)
+    int       msgget(key_t, int)
+    ssize_t   msgrcv(int, void*, size_t, long int, int)
+    int       msgsnd(int, const void*, size_t, int)
+
+cdef extern from '<sys/ipc.h>':
+    enum:
+        IPC_CREAT   # Create entry if key does not exist.
+        IPC_EXCL    # Fail if key exists.
+        IPC_NOWAIT  # Error if request must wait.
+
+        IPC_PRIVATE # Private key.
+
+        IPC_RMID    # Remove identifier.
+        IPC_SET     # Set options.
+        IPC_STAT    # Get options.
+
+    ctypedef short int key_t
+
+    key_t  ftok(const char*, int)

--- a/dnx_iptools/cprotocol_tools/cprotocol_tools.pxd
+++ b/dnx_iptools/cprotocol_tools/cprotocol_tools.pxd
@@ -16,12 +16,6 @@ cdef extern from '<arpa/inet.h>':
 
     in_addr_t inet_addr(char *cp)
 
-cdef extern from '<sys/msg.h>':
-    int       msgctl(int, int, void*)
-    int       msgget(key_t, int)
-    ssize_t   msgrcv(int, void*, size_t, long int, int)
-    int       msgsnd(int, const void*, size_t, int)
-
 cdef extern from '<sys/ipc.h>':
     enum:
         IPC_CREAT   # Create entry if key does not exist.
@@ -37,3 +31,9 @@ cdef extern from '<sys/ipc.h>':
     ctypedef short int key_t
 
     key_t  ftok(const char*, int)
+
+cdef extern from '<sys/msg.h>':
+    int       msgctl(int a, int b, void* c)
+    int       msgget(key_t a, int b)
+    ssize_t   msgrcv(int a, void* b, size_t c, long int d, int e)
+    int       msgsnd(int a, const void* b, size_t c, int d)

--- a/dnx_iptools/cprotocol_tools/cprotocol_tools.pyx
+++ b/dnx_iptools/cprotocol_tools/cprotocol_tools.pyx
@@ -125,15 +125,15 @@ cdef class MessageQueue:
     def __dealloc__(self):
         msgctl(self.id, IPC_RMID, NULL)
 
-    def connect(self, key_t key):
-        self.id = msgget(key, MQ_PERMISSIONS)
+    def connect(self, key):
+        self.id = msgget(<key_t>key, MQ_PERMISSIONS)
         if (self.id == -1):
             return ERR
 
         return OK
 
-    def create_queue(self, key_t key):
-        self.id = msgget(key, MQ_PERMISSIONS | IPC_CREAT)
+    def create_queue(self, key):
+        self.id = msgget(<key_t>key, MQ_PERMISSIONS | IPC_CREAT)
         if (self.id == -1):
             return ERR
 

--- a/dnx_iptools/cprotocol_tools/cprotocol_tools.pyx
+++ b/dnx_iptools/cprotocol_tools/cprotocol_tools.pyx
@@ -125,15 +125,21 @@ cdef class MessageQueue:
     def __dealloc__(self):
         msgctl(self.id, IPC_RMID, NULL)
 
-    def connect(self, key):
-        self.id = msgget(<key_t>key, MQ_PERMISSIONS)
+    def connect(self, pkey):
+
+        cdef key_t key = <key_t> pkey
+
+        self.id = msgget(key, MQ_PERMISSIONS)
         if (self.id == -1):
             return ERR
 
         return OK
 
-    def create_queue(self, key):
-        self.id = msgget(<key_t>key, MQ_PERMISSIONS | IPC_CREAT)
+    def create_queue(self, pkey):
+
+        cdef key_t key = <key_t> pkey
+
+        self.id = msgget(key, MQ_PERMISSIONS | IPC_CREAT)
         if (self.id == -1):
             return ERR
 

--- a/dnx_iptools/interface_ops.py
+++ b/dnx_iptools/interface_ops.py
@@ -24,7 +24,7 @@ __all__ = (
 
 NO_ADDRESS: int = -1
 
-_s: Socket = socket(AF_INET, SOCK_DGRAM)
+_s: Socket_T = socket(AF_INET, SOCK_DGRAM)
 DESCRIPTOR: int = _s.fileno()
 
 # NOTE: this may no longer be needed even though it was recently overhauled. the inclusion of the excluded

--- a/dnx_iptools/packet_classes.py
+++ b/dnx_iptools/packet_classes.py
@@ -65,16 +65,16 @@ class Listener:
         # INITIALIZING LISTENER
         # ======================
         # running main epoll/ socket loop.
-        self = cls()
-        self._setup()
+        listener = cls()
+        listener._setup()
 
         log.notice(f'{cls.__class__.__name__} initialization complete.')
 
         # starting a registration thread for all available interfaces and exit when complete
         for intf in cls._intfs:
-            Thread(target=self.__register, args=(intf,)).start()
+            Thread(target=listener.__register, args=(intf,)).start()
 
-        self.__listener(always_on, threaded)
+        listener.__run_listener(always_on, threaded)
 
     @classmethod
     def enable(cls, sock_fd: int, intf: str) -> None:
@@ -143,7 +143,7 @@ class Listener:
         '''
         pass
 
-    def __listener(self, always_on: bool, threaded: bool) -> NoReturn:
+    def __run_listener(self, always_on: bool, threaded: bool) -> NoReturn:
 
         # assigning all attrs as a local var for perf
         epoll_poll = self.__epoll.poll
@@ -348,18 +348,17 @@ class NFQueue:
     def __init__(self):
         self.inspection_queue = inspection_queue()
 
-        self._setup()
-
     @classmethod
     def run(cls, log: LogHandler_T, *, q_num: int) -> None:
 
         cls._log = log
 
         log.informational(f'{cls.__class__.__name__} initialization started.')
-        self = cls()
+        nfqueue = cls()
+        nfqueue._setup()
         log.notice(f'{cls.__class__.__name__} initialization complete.')
 
-        self.__queue(q_num)
+        nfqueue.__run_queue(q_num)
 
     def _setup(self):
         '''called prior to creating listener interface instances.
@@ -379,7 +378,7 @@ class NFQueue:
     #
     #     cls._proxy_callback = func
 
-    def __queue(self, q: int, /) -> NoReturn:
+    def __run_queue(self, q: int, /) -> NoReturn:
 
         for _ in RUN_FOREVER:
             # on failure, we will reinitialize the extension to start fresh

--- a/dnx_iptools/protocol_tools.py
+++ b/dnx_iptools/protocol_tools.py
@@ -24,7 +24,7 @@ from dnx_iptools.cprotocol_tools import calc_checksum, itoip
 # TYPING IMPORTS
 # ===============
 if (TYPE_CHECKING):
-    from dnx_gentools import Structure
+    from dnx_gentools import Structure_T
 
 __all__ = (
     'btoia', 'itoba',
@@ -105,7 +105,7 @@ def parse_query_name(data: Union[bytes, memoryview], offset: int = 0, *,
                      quick: bool = False) -> Union[int, tuple[int, str, bool]]:
     '''parse dns name from sent in data.
 
-    if quick is set, returns offset only, otherwise offset, qname decoded, and whether its local domain.
+    if quick is set, returns offset only, otherwise offset, qname decoded, and whether its local domain is returned.
     '''
     idx: int = offset
     has_ptr: bool = False
@@ -166,9 +166,6 @@ def create_dns_query_header(dns_id, arc=0, *, cd):
 
     return dns_header_pack(dns_id, bit_fields, 1, 0, 0, arc)
 
-
-icmp_header_template: Structure = PR_ICMP_HDR((('type', 8), ('code', 0)))
-
 # will ping specified host. to be used to prevent duplicate ip address handouts.
 def icmp_reachable(host_ip: int) -> bool:
 
@@ -177,11 +174,14 @@ def icmp_reachable(host_ip: int) -> bool:
     except CalledProcessError:
         return False
 
+
+icmp_header_template: Structure_T = PR_ICMP_HDR((('type', 8), ('code', 0)))
+
 def init_ping(timeout: float = .25) -> Callable[[str, int], bool]:
     '''function factory that returns a ping function object optimized for speed.
 
-    not thread safe within a single ping object, but is thread safe between multiple ping objects.'''
-
+    not thread safe within a single ping object, but is thread safe between multiple ping objects.
+    '''
     ping_sock = socket(AF_INET, SOCK_RAW, PROTO.ICMP)
     ping_sock.settimeout(timeout)
 
@@ -196,7 +196,6 @@ def init_ping(timeout: float = .25) -> Callable[[str, int], bool]:
         replies_rcvd = 0
         for i in range(count):
 
-            # NOTE: this is dumb. should only call assemble once.
             icmp.sequence = i
             icmp.checksum = btoia(calc_checksum(icmp.assemble()))
 

--- a/dnx_netmods/dhcp_server/__init__.py
+++ b/dnx_netmods/dhcp_server/__init__.py
@@ -23,10 +23,10 @@ def run():
 # ================
 # TYPING IMPORTS
 # ================
-from typing import TYPE_CHECKING, Type
+from typing import TYPE_CHECKING
 
 if (TYPE_CHECKING):
-    from typing import TypeAlias
+    from typing import Type, TypeAlias
 
     __all__ = (
         'DHCPServer', 'Leases',

--- a/dnx_netmods/dhcp_server/dhcp_server_automate.py
+++ b/dnx_netmods/dhcp_server/dhcp_server_automate.py
@@ -160,7 +160,7 @@ class ServerConfiguration(ConfigurationMixinBase):
 
             # this is providing the first portion of creating a socket. this will allow the system to create the socket
             # store the file descriptor id, and then bind when ready per normal registration logic.
-            l_sock: Socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            l_sock: Socket_T = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
             sock_refs = (l_sock, l_sock.fileno())
 

--- a/dnx_routines/logging/log_client.py
+++ b/dnx_routines/logging/log_client.py
@@ -130,7 +130,7 @@ def _log_handler() -> LogHandler:
     # ------------------
     # DB SERVICE SOCKET
     # ------------------
-    db_client: Socket = socket(AF_UNIX, SOCK_DGRAM)
+    db_client: Socket_T = socket(AF_UNIX, SOCK_DGRAM)
 
     db_sendmsg = db_client.sendmsg
 

--- a/dnx_secmods/cfirewall/include/msg_q.h
+++ b/dnx_secmods/cfirewall/include/msg_q.h
@@ -1,0 +1,18 @@
+#define MQ_PERMISSIONS  0600
+#define MQ_MESSAGE_SIZE 2048
+
+#define MQ_CFIREWALL    0;
+#define MQ_IP_PROXY     1;
+#define MQ_DNS_PROXY    2;
+#define MQ_IDS_IPS      3;
+
+
+struct mq_handle {
+    int     ro;  // 0/1 flag for whether this process owns the queue and is responsible for cleanup
+    int     id;
+    char    key[32];
+}
+
+extern int attach(self, int mq_idx, bool ro);
+extern int send_msg(int mq_idx, void *data, uint32_t prio);
+extern int recv_msg(int mq_idx, char *data, uint32_t prio);

--- a/dnx_secmods/cfirewall/include/rules.h
+++ b/dnx_secmods/cfirewall/include/rules.h
@@ -37,7 +37,7 @@ enum sec_profiles {
     NONE,
     IP_PROXY,
     DNS_PROXY,
-    IPS_IDS
+    IDS_IPS
 };
 
 typedef struct ZoneMap {

--- a/dnx_secmods/cfirewall/src/msg_q.c
+++ b/dnx_secmods/cfirewall/src/msg_q.c
@@ -1,0 +1,74 @@
+#include config.h
+#include cfirewall.h
+#include msg_q.h
+
+/*
+  Queue indexes
+  0 - CFIREWALL
+  1 - IP PROXY
+  2 - DNS PROXY
+  3 - IDS/IPS
+*/
+char MQ_KEY_MAP[4][32] = {"/DNX-CFIREWALL", "/DNX-IP-PROXY", "/DNX-DNS-PROXY", "/DNX-IDS-IPS"};
+
+struct mq_handle MQ_HANDLES[4];
+
+
+int
+attach(self, int mq_idx, bool ro)
+{
+    int             ret
+    struct mq_attr  attr
+
+    // setting read only flag
+    MQ_HANDLES[mq_idx].ro = ro
+
+    // opening queue. create and set parameters if set for writing.
+    if (ro) {
+        ret = mq_open(self.key, O_RDONLY, 0, NULL);
+    }
+    else {
+        attr.mq_maxmsg  = MQ_MESSAGE_LIMIT;
+        attr.mq_msgsize = MQ_MESSAGE_SIZE;
+
+        ret = mq_open(self.key, O_WRONLY | O_CREAT, MQ_PERMISSIONS, &attr);
+    }
+
+    if ((int) ret == -1) {
+        perror("connect error");
+        return ERR;
+    }
+
+    // copy key over for easy unlink
+    strncpy(MQ_HANDLES[mq_idx], MQ_KEY_MAP[key], 32);
+
+    return OK;
+}
+
+int
+send_msg(int mq_idx, void *data, uint32_t prio)
+{
+    int     ret;
+
+    ret = mq_send(self.id, <const char*>&data[0], data.shape[0], prio);
+    if (ret == -1) {
+        perror("send error");
+        return ERR;
+    }
+
+    return ret;
+}
+
+int
+recv_msg(int mq_idx, char *data, uint32_t prio)
+{
+    int     ret;
+
+    ret = mq_receive(self.id, data, MQ_MESSAGE_SIZE, &prio);
+    if (ret == -1) {
+        perror("receive error");
+        return ERR;
+    }
+
+    return OK;
+}

--- a/dnx_secmods/dns_proxy/dns_proxy.py
+++ b/dnx_secmods/dns_proxy/dns_proxy.py
@@ -31,7 +31,7 @@ PREPARE_AND_SEND = ProxyResponse.prepare_and_send
 #   ProxyConfiguration - provides config management between memory and filesystem
 #   NFQueue - provides packet data from Linux Netfilter NFQUEUE sub-system
 # =====================
-class DNSProxy(NFQueue, ProxyConfiguration):
+class DNSProxy(ProxyConfiguration, NFQueue):
 
     _packet_parser: ClassVar[ProxyParser] = DNSPacket.netfilter_recv
 

--- a/dnx_secmods/dns_proxy/dns_proxy.py
+++ b/dnx_secmods/dns_proxy/dns_proxy.py
@@ -43,9 +43,11 @@ class DNSProxy(ProxyConfiguration, NFQueue):
         ProxyResponse.setup(Log)
 
         for i in range(self.DEFAULT_THREAD_COUNT):
-            Thread(target=self.inspection_worker).start()
+            Thread(target=self.inspection_worker, args=(i,)).start()
 
-    def inspection_worker(self):
+    def inspection_worker(self, i: int) -> NoReturn:
+        Log.informational(f'[proxy/worker][{i}] inspection thread started')
+
         for _ in RUN_FOREVER:
             packet = self.inspection_queue.get()
 

--- a/dnx_secmods/dns_proxy/dns_proxy.py
+++ b/dnx_secmods/dns_proxy/dns_proxy.py
@@ -101,8 +101,7 @@ def pre_inspect(packet: DNSPacket) -> bool:
     return DONT_INSPECT_PACKET
 
 
-# this is where the system decides whether to block dns query/sinkhole or to allow. notification will be done
-# via the request tracker upon returning the signature scan result
+# this is where the system decides whether to block dns query/sinkhole or to allow.
 def inspect(packet: DNSPacket) -> DNS_REQUEST_RESULTS:
     # NOTE: request_ident[0] is a string representation of ip addresses. this is currently needed as the whitelists
     #  are stored in this format and we have since moved away from this format on the back end.
@@ -112,7 +111,7 @@ def inspect(packet: DNSPacket) -> DNS_REQUEST_RESULTS:
     enum_categories = []
 
     # TLD (top level domain) block
-    # dns whitelist does not override tld blocks at the moment. this is most likely the desired setup
+    # url whitelist does not override tld blocks at the moment.
     if _tld_get(packet.tld):
 
         return DNS_REQUEST_RESULTS(True, 'tld filter', TLD_CAT[packet.tld])

--- a/dnx_secmods/dns_proxy/dns_proxy_automate.py
+++ b/dnx_secmods/dns_proxy/dns_proxy_automate.py
@@ -254,7 +254,7 @@ class ServerConfiguration(ConfigurationMixinBase):
         return thread information to be run.
         '''
         udp_query: bytes = create_dns_query_header(dns_id=69, cd=1) + b'\x0bdnxfirewall\x03com\x00\x00\x01\x00\x01'
-        udp_reach_sock: Socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        udp_reach_sock: Socket_T = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         udp_reach_sock.settimeout(CONNECT_TIMEOUT)
 
         tls_context: SSLContext = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
@@ -306,7 +306,7 @@ class ServerConfiguration(ConfigurationMixinBase):
         self._initialize.done()
 
     @looper(FIVE_SEC)
-    def _udp_reachability(self, udp_query: bytes, udp_sock: Socket):
+    def _udp_reachability(self, udp_query: bytes, udp_sock: Socket_T):
         public_resolvers = self.__class__.public_resolvers
 
         if (self.protocol is not PROTO.UDP and not self.__class__.udp_fallback):
@@ -353,7 +353,7 @@ class ServerConfiguration(ConfigurationMixinBase):
 
             Log.debug(f'[{secure_server}/DNS_TLS] Checking reachability of remote DNS server.')
 
-            sock: Socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock: Socket_T = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.settimeout(CONNECT_TIMEOUT)
 
             secure_socket = tls_context.wrap_socket(sock, server_hostname=secure_server)

--- a/dnx_secmods/dns_proxy/dns_proxy_cache.py
+++ b/dnx_secmods/dns_proxy/dns_proxy_cache.py
@@ -18,12 +18,13 @@ from dns_proxy_log import Log
 # TYPING IMPORTS
 # ===============
 if (TYPE_CHECKING):
-    from dnx_secmods.dns_proxy import DNSCache, RequestTracker
+    from dnx_gentools import RequestQueue_T
+    from dnx_secmods.dns_proxy import DNSCache
 
     from dns_proxy_packets import ClientQuery
 
 __all__ = (
-    'dns_cache', 'request_tracker',
+    'dns_cache',
     
     'NO_QNAME_RECORD', 'QNAME_NOT_FOUND'
 )
@@ -31,7 +32,27 @@ __all__ = (
 NO_QNAME_RECORD = QNAME_RECORD(-1, -1, [])
 QNAME_NOT_FOUND = QNAME_RECORD_UPDATE(-1, [])
 
-def dns_cache(*, dns_packet: Callable[[str], ClientQuery], request_handler: Callable[[int, ClientQuery], None]) -> DNSCache:
+# TODO: it might be worth making dns_packet callback set via set_* method since we doing for the request_queue already
+def dns_cache(*, dns_packet: Callable[[str], ClientQuery]) -> DNSCache:
+    '''factory function providing subclass of dict as custom data structure for dealing with the local caching of dns
+    records and poller operations for refresh and cleanup.
+
+    containers handled by class:
+        general dict - standard cache storage
+        private dict - top domains cache storage
+        private Counter - tracking number of times a domain is queried
+
+    required callbacks via arguments
+
+        packet (*reference to packet class*)
+
+    required callbacks via set_* method
+
+        request_queue (*reference to dns server request queue*)
+    '''
+    # note: expect "self" as first arg, so we will have to fudge it
+    # see if we can get away with not initializing nonlocal var.
+    request_queue_insert: Callable[[int, ClientQuery], None]  # = None
 
     _top_domains: list = load_configuration('dns_server', ext='cache', cfg_type='global').get('top_domains')
 
@@ -112,28 +133,14 @@ def dns_cache(*, dns_packet: Callable[[str], ClientQuery], request_handler: Call
 
         # response will be identified by "None" for client address
         for domain in top_domains:
-            request_handler(1, dns_packet(domain))
+
+            # first arg is to fulfill "self" positional arg
+            request_queue_insert(1, dns_packet(domain))
             fast_sleep(.1)
 
         Log.debug('expired records cleared from cache and top domains refreshed')
 
     class _DNSCache(dict):
-        '''subclass of dict to provide a custom data structure for dealing with the local caching of dns records.
-
-        containers handled by class:
-            general dict - standard cache storage
-            private dict - top domains cache storage
-            private Counter - tracking number of times a domain is queried
-
-        initialization is the same as a dict, with the addition of two required arguments for callback references
-        to the dns server.
-
-            packet (*reference to packet class*)
-            request_handler (*reference to dns server request handler function*)
-
-        if the above callbacks are not set, the top domain's caching system will NOT actively update records, but the
-        counts will still be accurate/usable.
-        '''
         __slots__ = ()
 
         # searching key directly will return calculated ttl and associated records
@@ -179,6 +186,11 @@ def dns_cache(*, dns_packet: Callable[[str], ClientQuery], request_handler: Call
 
             return self[query_name]
 
+        def set_request_queue(self, request_queue: RequestQueue_T) -> None:
+            nonlocal request_queue_insert
+
+            request_queue_insert = request_queue.insert
+
         def start_pollers(self):
 
             threading.Thread(target=auto_clear, args=(self,)).start()
@@ -188,54 +200,3 @@ def dns_cache(*, dns_packet: Callable[[str], ClientQuery], request_handler: Call
         return _DNSCache
 
     return _DNSCache()
-
-
-def request_tracker() -> RequestTracker:
-    '''Basic queueing mechanism for DNS requests received by the server.
-
-    The main feature of the queue is to provide efficient thread blocking via Thread Events over a busy loop.
-    This is a very lightweight version of the standard lib Queue and uses a deque as its primary data structure.
-    '''
-    request_ready = threading.Event()
-    wait_for_request = request_ready.wait
-    notify_ready = request_ready.set
-    clear_ready = request_ready.clear
-
-    _list = list
-
-    request_queue = deque()
-    request_queue_append = request_queue.append
-    request_queue_get = request_queue.popleft
-
-    class _RequestTracker:
-
-        @staticmethod
-        def return_ready() -> ClientQuery:
-            '''function generator returning requests from queue in FIFO order.
-
-            calls will block if the queue is empty and will never time out.
-            '''
-            # blocking until at least one request has been received
-            wait_for_request()
-
-            # immediately clearing event, so we don't have to worry about it after loop. this prevents having to deal
-            # with scenarios where a request was received in just after while loop, but just before reset. in this case
-            # the request would be stuck until another was received.
-            clear_ready()
-
-            while request_queue:
-                yield request_queue_get()
-
-        @staticmethod
-        # NOTE: first arg is because this gets referenced/called via an instance.
-        def insert(_, client_query: ClientQuery) -> None:
-
-            request_queue_append(client_query)
-
-            # notifying return_ready that there is a query ready to forward
-            notify_ready()
-
-    if (TYPE_CHECKING):
-        return _RequestTracker
-
-    return _RequestTracker()

--- a/dnx_secmods/dns_proxy/dns_proxy_cache.py
+++ b/dnx_secmods/dns_proxy/dns_proxy_cache.py
@@ -56,7 +56,7 @@ def dns_cache(*, dns_packet: Callable[[str], ClientQuery]) -> DNSCache:
     _top_domains: list = load_configuration('dns_server', ext='cache', cfg_type='global').get('top_domains')
 
     domain_counter: Counter[str, int] = Counter({dom: cnt for cnt, dom in enumerate(reversed(_top_domains))})
-    counter_lock: Lock = threading.Lock()
+    counter_lock: Lock_T = threading.Lock()
 
     top_domain_filter = tuple(load_top_domains_filter())
 

--- a/dnx_secmods/dns_proxy/dns_proxy_cache.py
+++ b/dnx_secmods/dns_proxy/dns_proxy_cache.py
@@ -50,9 +50,8 @@ def dns_cache(*, dns_packet: Callable[[str], ClientQuery]) -> DNSCache:
 
         request_queue (*reference to dns server request queue*)
     '''
-    # note: expect "self" as first arg, so we will have to fudge it
-    # see if we can get away with not initializing nonlocal var.
-    request_queue_insert: Callable[[int, ClientQuery], None]  # = None
+    # will be set through class as nonlocal
+    request_queue_insert: Callable[[ClientQuery], None]
 
     _top_domains: list = load_configuration('dns_server', ext='cache', cfg_type='global').get('top_domains')
 
@@ -135,7 +134,7 @@ def dns_cache(*, dns_packet: Callable[[str], ClientQuery]) -> DNSCache:
         for domain in top_domains:
 
             # first arg is to fulfill "self" positional arg
-            request_queue_insert(1, dns_packet(domain))
+            request_queue_insert(dns_packet(domain))
             fast_sleep(.1)
 
         Log.debug('expired records cleared from cache and top domains refreshed')

--- a/dnx_secmods/dns_proxy/dns_proxy_cache.py
+++ b/dnx_secmods/dns_proxy/dns_proxy_cache.py
@@ -133,7 +133,6 @@ def dns_cache(*, dns_packet: Callable[[str], ClientQuery]) -> DNSCache:
         # response will be identified by "None" for client address
         for domain in top_domains:
 
-            # first arg is to fulfill "self" positional arg
             request_queue_insert(dns_packet(domain))
             fast_sleep(.1)
 

--- a/dnx_secmods/dns_proxy/dns_proxy_packets.py
+++ b/dnx_secmods/dns_proxy/dns_proxy_packets.py
@@ -136,7 +136,7 @@ class ClientQuery:
         # setting additional data flag in dns header if detected
         arc = 1 if self.additional_records else 0
 
-        # initializing byte array with (2) bytes. these get overwritten with query len actual after processing
+        # initializing bytearray with (2) bytes. these get overwritten with query len actual after processing
         send_data = bytearray(2)
 
         send_data += dns_header_pack(dns_id, self.rd | self.ad | self.cd, 1, 0, 0, arc)
@@ -165,7 +165,6 @@ class ClientQuery:
         self.qname = qname
         self.qtype = 1
 
-        self.qr = 0
         self.rd = DNS_MASK.RD
         self.ad = DNS_MASK.AD
         self.cd = DNS_MASK.CD

--- a/dnx_secmods/dns_proxy/dns_proxy_packets.py
+++ b/dnx_secmods/dns_proxy/dns_proxy_packets.py
@@ -165,6 +165,7 @@ class ClientQuery:
         self.qname = qname
         self.qtype = 1
 
+        self.qr = 0
         self.rd = DNS_MASK.RD
         self.ad = DNS_MASK.AD
         self.cd = DNS_MASK.CD

--- a/dnx_secmods/dns_proxy/dns_proxy_protocols.py
+++ b/dnx_secmods/dns_proxy/dns_proxy_protocols.py
@@ -87,7 +87,7 @@ class UDPRelay(ProtoRelay):
 
         Log.informational(f'[{server_ip}/UDP] Opening socket.')
 
-        dns_sock: Socket = socket(AF_INET, SOCK_DGRAM)
+        dns_sock: Socket_T = socket(AF_INET, SOCK_DGRAM)
 
         # udp connect allows 'send' method to be used, but does not actually have an underlying connection
         dns_sock.connect((server_ip, PROTO.DNS))
@@ -119,7 +119,7 @@ class TLSRelay(ProtoRelay):
         self._tls_context.load_verify_locations(CERTIFICATE_STORE)
 
         # tls connection keepalive. hard set to 8 seconds, but can be enabled/disabled
-        self._keepalive_status: Event = threading.Event()
+        self._keepalive_status: Event_T = threading.Event()
         threading.Thread(target=self._keepalive_run).start()
 
     @dnx_queue(Log, name='TLSRelay')
@@ -259,7 +259,7 @@ class TLSRelay(ProtoRelay):
 
         Log.informational(f'[{tls_server}/{self._protocol.name}] Opening secure socket.')
 
-        sock: Socket = socket(AF_INET, SOCK_STREAM)
+        sock: Socket_T = socket(AF_INET, SOCK_STREAM)
         sock.settimeout(CONNECT_TIMEOUT)
 
         dot_sock = self._tls_context.wrap_socket(sock, server_hostname=tls_server)

--- a/dnx_secmods/dns_proxy/dns_proxy_protocols.py
+++ b/dnx_secmods/dns_proxy/dns_proxy_protocols.py
@@ -178,7 +178,7 @@ class TLSRelay(ProtoRelay):
         conn_recv = self._relay_conn.recv
         keepalive_reset = self._keepalive_status.set
 
-        responde_handler_add = self._dns_server.response_handler.add
+        response_handler_add = self._dns_server.response_handler.add
 
         recv_buf = bytearray(2048)
         recv_buffer = memoryview(recv_buf)
@@ -232,7 +232,7 @@ class TLSRelay(ProtoRelay):
 
                     # using memoryview(), so we need to copy the data to bytes first or it will corrupt the original
                     # data which is running concurrent to the receiving processor.
-                    responde_handler_add(bytes(data[:data_len]))
+                    response_handler_add(bytes(data[:data_len]))
 
                     b_ct = 0
 

--- a/dnx_secmods/dns_proxy/dns_proxy_protocols.py
+++ b/dnx_secmods/dns_proxy/dns_proxy_protocols.py
@@ -55,16 +55,15 @@ class UDPRelay(ProtoRelay):
 
             self._relay_conn = self._connect_udp(dns_server['ip_address'])
 
-            return True
+            return OK
 
         Log.critical(f'[{self._protocol}] No DNS servers available.')
 
-        return False
+        return ERR
 
-    # receive data from server. if dns response will call parse method else will close the socket.
     def _recv_handler(self) -> None:
         conn_recv = self._relay_conn.recv
-        responder_add = self._dns_server.responder.add
+        response_handler_add = self._dns_server.response_handler.add
 
         for _ in RUN_FOREVER:
             try:
@@ -76,7 +75,7 @@ class UDPRelay(ProtoRelay):
             if (not data_from_server):
                 continue
 
-            responder_add(data_from_server)
+            response_handler_add(data_from_server)
 
             # resetting fail detection
             self._last_rcvd  = fast_time()
@@ -157,12 +156,12 @@ class TLSRelay(ProtoRelay):
                 continue
 
             # attempting to connect via tls.
-            # if successful will return True, otherwise mark server as down and try the next server.
+            # if successful returns True, otherwise mark server as down and try the next server.
             self._relay_conn = self._connect_tls(tls_server['ip_address'])
             if (self._relay_conn is not NULL_SOCK):
                 threading.Thread(target=self._recv_handler).start()
 
-                return True
+                return OK
 
             self.mark_server_down(remote_server=tls_server['ip_address'])
 
@@ -170,7 +169,7 @@ class TLSRelay(ProtoRelay):
         self._dns_server.tls_down = True
         Log.error(f'[{self._protocol}] No DNS servers available.')
 
-        return False
+        return ERR
 
     # receive data from server and call parse method when a valid message is recvd, else will close the socket.
     def _recv_handler(self) -> None:
@@ -179,7 +178,7 @@ class TLSRelay(ProtoRelay):
         conn_recv = self._relay_conn.recv
         keepalive_reset = self._keepalive_status.set
 
-        responder_add = self._dns_server.responder.add
+        responde_handler_add = self._dns_server.response_handler.add
 
         recv_buf = bytearray(2048)
         recv_buffer = memoryview(recv_buf)
@@ -192,10 +191,10 @@ class TLSRelay(ProtoRelay):
 
         for _ in RUN_FOREVER:
             try:
-                # recv_into | no need to specify the amount to return and mtu covers max len.
-                # not inplace adding byte count to protect against cases where a public resolver sends a single
-                # response over multiple packets and connection is closed in between (this is highly unlikely since
-                # most cases it would be via timeout, but I have seen worse).
+                # recv_into | no need to specify the amount to return because mtu covers max len.
+                # keeping nbyte separate to protect against cases where a public resolver sends a single response
+                # over multiple packets and connection is closed in between (highly unlikely since most cases it
+                # would be via timeout, but I have seen worse).
                 nbytes: int = conn_recv(recv_buffer)
             except OSError:
                 break
@@ -214,7 +213,7 @@ class TLSRelay(ProtoRelay):
             # transferring data from single packet buffer to general processing buffer, memoryview()
             processing_buffer[b_ct:b_ct + nbytes] = recv_buffer[:nbytes]
 
-            # incrementing the amount of filled bytes in processing buffer accounting for 2 byte len field
+            # incrementing byte count of processing buffer (accounts for 2 byte len field)
             b_ct += nbytes
 
             # =========================
@@ -231,9 +230,9 @@ class TLSRelay(ProtoRelay):
                 # normal case - exactly 1 complete dns response in buffer
                 if (b_ct == request_len):
 
-                    # using memoryview(), so need to copy response data, otherwise it will corrupt the original data
-                    # which is running concurrent to the receiving processor.
-                    responder_add(bytes(data[:data_len]))
+                    # using memoryview(), so we need to copy the data to bytes first or it will corrupt the original
+                    # data which is running concurrent to the receiving processor.
+                    responde_handler_add(bytes(data[:data_len]))
 
                     b_ct = 0
 
@@ -248,8 +247,8 @@ class TLSRelay(ProtoRelay):
 
                     processing_buffer[:b_ct] = extra_bytes
 
-                # more data is needed for a complete response. NOTE: this scenario is kind of dumb
-                # and shouldn't happen unless the server sends length of record and record separately.
+                # more data is needed for a complete response likely because the rmeote server sent the length of the
+                # record and record separately.
                 # elif (b_ct < data_len): break
                 else: break
 

--- a/dnx_secmods/dns_proxy/dns_proxy_server.py
+++ b/dnx_secmods/dns_proxy/dns_proxy_server.py
@@ -54,7 +54,7 @@ RELAY_MAP: dict[PROTO, Callable[[DNS_SEND], None]] = {
 }
 
 # acquired prior to randomly selecting dns id
-dns_id_lock: Lock = threading.Lock()
+dns_id_lock: Lock_T = threading.Lock()
 
 # ======================
 # MAIN DNS SERVER CLASS
@@ -126,8 +126,8 @@ class DNSServer(ServerConfiguration, Listener):
 
         return INSPECT_PACKET
 
-    def _listener_sock(self, intf: str, intf_ip: int) -> Socket:
-        l_sock: Socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    def _listener_sock(self, intf: str, intf_ip: int) -> Socket_T:
+        l_sock: Socket_T = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
         l_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         l_sock.setblocking(False)

--- a/dnx_secmods/dns_proxy/dns_proxy_server.py
+++ b/dnx_secmods/dns_proxy/dns_proxy_server.py
@@ -102,9 +102,8 @@ class DNSServer(ServerConfiguration, Listener):
         UDPRelay.run(self.__class__)
         TLSRelay.run(self.__class__, fallback_relay=UDPRelay.relay)
 
-        # NOTE: A/NS records are supported only. consider expanding
-
     def _pre_inspect(self, client_query: ClientQuery) -> bool:
+        # NOTE: A/NS records are supported only. consider expanding
         if (client_query.qr != DNS.QUERY or client_query.qtype not in [DNS.A, DNS.NS]):
             return False
 

--- a/dnx_secmods/dns_proxy/dns_proxy_server.py
+++ b/dnx_secmods/dns_proxy/dns_proxy_server.py
@@ -20,7 +20,7 @@ from dnx_iptools.packet_classes import Listener
 from dns_proxy_automate import ServerConfiguration
 from dns_proxy_protocols import UDPRelay, TLSRelay
 from dns_proxy_packets import ClientQuery, ttl_rewrite
-from dns_proxy_cache import dns_cache, request_tracker, QNAME_NOT_FOUND
+from dns_proxy_cache import dns_cache, QNAME_NOT_FOUND
 from dns_proxy_log import Log
 
 # ===============
@@ -33,21 +33,13 @@ __all__ = (
     'DNSServer',
 )
 
-# =======================
-# RCVD REQUEST PROCESSOR
-# =======================
-# TODO: fix this typing issue
-REQ_TRACKER: RequestTracker = request_tracker()
-REQ_TRACKER_INSERT = REQ_TRACKER.insert
-
 # ======================
 # DNS RECORD CACHE DICT
 # ======================
 # initializing dns cache/ sending in reference to needed methods for top domains
 # .start_pollers() call is required for top domains and cache clearing functionality
 DNS_CACHE = dns_cache(
-    dns_packet=ClientQuery.init_local_query,
-    request_handler=REQ_TRACKER_INSERT
+    dns_packet=ClientQuery.init_local_query
 )
 
 DNS_CACHE_ADD = DNS_CACHE.add
@@ -61,7 +53,7 @@ RELAY_MAP: dict[PROTO, Callable[[DNS_SEND], None]] = {
     PROTO.DNS_TLS: TLSRelay.relay.add
 }
 
-# acquired prior to randomly selected dns id
+# acquired prior to randomly selecting dns id
 dns_id_lock: Lock = threading.Lock()
 
 # ======================
@@ -82,67 +74,26 @@ class DNSServer(ServerConfiguration, Listener):
     )
 
     def __init__(self):
-
-        super().__init__()
-
-        # assigning object methods to prevent lookup
+        # assigning object methods to reduce lookups
         self._request_map_pop: Callable[[int, ...], ClientQuery] = self._request_map.pop
         self._dns_records_get: Callable[[str], int] = self.dns_records.get
 
-    def handle_query(self, client_query: ClientQuery) -> None:
-
-        # generating dns query packet data
-        send_data = client_query.generate_dns_query(
-            # returns new unique id after storing {id: request info} in request map
-            get_unique_id(self._request_map, client_query), self.protocol
-        )
-
-        # queue send_data to currently enabled protocol/relay for sending to external resolver.
-        # request is sent for logging purposes and may be temporary.
-        RELAY_MAP[self.protocol](
-            DNS_SEND(client_query.qname, send_data)
-        )
-
-    @dnx_queue(Log, name='DNSServer')
-    def responder(self, received_data: bytes) -> None:
-        # dns id is the first 2 bytes in the dns header
-        dns_id: int = btoia(received_data[:2])
-
-        # recently moved here for clarity. silently drops keepalive responses since they are not needed.
-        if (dns_id == DNS.KEEPALIVE):
-            return
-
-        client_query: ClientQuery = self._request_map_pop(dns_id, INVALID_RESPONSE)
-        if (not client_query):
-            return
-
-        try:
-            query_response, cache_data = ttl_rewrite(received_data, client_query.dns_id)
-        except Exception as E:
-            Log.error(f'[parser/server response] {E}')
-        else:
-            if (not client_query.top_domain):
-                send_to_client(client_query, query_response)
-
-            if (cache_data.records):
-                DNS_CACHE_ADD(client_query.qname, cache_data)
+        super().__init__()
 
     def _setup(self) -> None:
-
-        # setting parent class callback to allow custom actions on subclasses
-        self.__class__.set_proxy_callback(func=REQ_TRACKER_INSERT)
 
         self.configure()
 
         # ==========================
         # SENDER / RECEIVER QUEUES
         # ==========================
-        threading.Thread(target=self.responder).start()
-        threading.Thread(target=self._request_queue).start()
+        threading.Thread(target=self.response_handler).start()
+        threading.Thread(target=self.request_handler).start()
 
         # ==========================
         # TOP DOMAINS / CACHE CLEAR
         # ==========================
+        DNS_CACHE.set_request_queue(self.request_queue)
         DNS_CACHE.start_pollers()
 
         # ==========================
@@ -151,24 +102,8 @@ class DNSServer(ServerConfiguration, Listener):
         UDPRelay.run(self.__class__)
         TLSRelay.run(self.__class__, fallback_relay=UDPRelay.relay)
 
-    # thread to handle all received requests from the listener.
-    def _request_queue(self) -> NoReturn:
-        return_ready = REQ_TRACKER.return_ready
+        # NOTE: A/NS records are supported only. consider expanding
 
-        for _ in RUN_FOREVER:
-
-            # generator that blocks until at least 1 request is in the queue.
-            # if multiple requests are present, they will be yielded back until the queue is empty.
-            for client_query in return_ready():
-
-                qname_cache = cache_available(client_query)
-                if (qname_cache is QNAME_NOT_FOUND):
-                    self.handle_query(client_query)
-
-                else:
-                    send_to_client(client_query, client_query.generate_cached_response(qname_cache))
-
-    # NOTE: A/NS records are supported only. consider expanding
     def _pre_inspect(self, client_query: ClientQuery) -> bool:
         if (client_query.qr != DNS.QUERY or client_query.qtype not in [DNS.A, DNS.NS]):
             return False
@@ -197,6 +132,61 @@ class DNSServer(ServerConfiguration, Listener):
         l_sock.bind((itoip(intf_ip), PROTO.DNS))
 
         return l_sock
+
+    # thread to handle all received requests from the listener.
+    def request_handler(self) -> NoReturn:
+        return_ready = self.request_queue.return_ready
+        pre_inspection = self._pre_inspect
+
+        for _ in RUN_FOREVER:
+
+            # generator that blocks until at least 1 request is in the queue.
+            # if multiple requests are present, they will be yielded back until the queue is empty.
+            for client_query in return_ready():
+
+                # fast path for certain conditions
+                if not pre_inspection(client_query):
+                    continue
+
+                qname_cache = cache_available(client_query)
+                if (qname_cache is not QNAME_NOT_FOUND):
+                    send_to_client(client_query, client_query.generate_cached_response(qname_cache))
+
+                else:
+                    # generating dns query packet data
+                    send_data = client_query.generate_dns_query(
+                        # returns new unique id after storing {id: request info} in request map
+                        get_unique_id(self._request_map, client_query), self.protocol
+                    )
+
+                    # queue send_data to currently enabled protocol/relay for sending to external resolver
+                    RELAY_MAP[self.protocol](
+                        DNS_SEND(client_query.qname, send_data)
+                    )
+
+    @dnx_queue(Log, name='DNSServer')
+    def response_handler(self, received_data: bytes) -> None:
+        # dns id is the first 2 bytes in the dns header
+        dns_id: int = btoia(received_data[:2])
+
+        # recently moved here for clarity. silently drops keepalive responses since they are not needed.
+        if (dns_id == DNS.KEEPALIVE):
+            return
+
+        client_query: ClientQuery = self._request_map_pop(dns_id, INVALID_RESPONSE)
+        if (not client_query):
+            return
+
+        try:
+            query_response, cache_data = ttl_rewrite(received_data, client_query.dns_id)
+        except Exception as E:
+            Log.error(f'[parser/server response] {E}')
+        else:
+            if (not client_query.top_domain):
+                send_to_client(client_query, query_response)
+
+            if (cache_data.records):
+                DNS_CACHE_ADD(client_query.qname, cache_data)
 
 
 # ==================

--- a/dnx_secmods/ids_ips/__init__.py
+++ b/dnx_secmods/ids_ips/__init__.py
@@ -12,14 +12,14 @@ if INITIALIZE_MODULE('ips-ids'):
 
     from dnx_gentools.def_enums import Queue
 
-    from ids_ips import IPS_IDS
+    from ids_ips import IDS_IPS
     from ids_ips_log import Log
 
     Log.run(name='ips')
 
 
 def run():
-    IPS_IDS.run(Log, q_num=Queue.IPS_IDS)
+    IDS_IPS.run(Log, q_num=Queue.IDS_IPS)
 
 
 # ================
@@ -31,17 +31,17 @@ if (TYPE_CHECKING):
     from typing import TypeAlias
 
     __all__ = (
-        'IPS_IDS', 'IPSPacket',
+        'IDS_IPS', 'IPSPacket',
 
         # TYPES
-        'IPS_IDS_T', 'IPSPacket_T'
+        'IDS_IPS_T', 'IPSPacket_T'
     )
 
-    from ids_ips import IPS_IDS
+    from ids_ips import IDS_IPS
     from ids_ips_packets import IPSPacket
 
     # ======
     # TYPES
     # ======
-    IPS_IDS_T:   TypeAlias = Type[IPS_IDS]
+    IDS_IPS_T:   TypeAlias = Type[IDS_IPS]
     IPSPacket_T: TypeAlias = Type[IPSPacket]

--- a/dnx_secmods/ids_ips/ids_ips.py
+++ b/dnx_secmods/ids_ips/ids_ips.py
@@ -281,6 +281,9 @@ def ddos_detected(tracker: dict, packet: IPSPacket) -> bool:
     tracked_ip['count'] += 1
     tracked_ip['last_seen'] = packet.timestamp
 
+    # ====================
+    # INSPECTION DECISION
+    # ====================
     # if the ddos limit is exceeded and the host is not yet marked, return active ddos and add ip to tracker
     if threshold_exceeded(tracked_ip, packet):
 
@@ -292,7 +295,6 @@ def ddos_detected(tracker: dict, packet: IPSPacket) -> bool:
         return True
 
     return False
-
 
 def threshold_exceeded(tracked_ip, packet):
     elapsed_time = packet.timestamp - tracked_ip['initial']

--- a/dnx_secmods/ids_ips/ids_ips.py
+++ b/dnx_secmods/ids_ips/ids_ips.py
@@ -8,8 +8,8 @@ from copy import copy
 from collections import defaultdict
 
 from dnx_gentools.def_typing import *
-from dnx_gentools.def_constants import *
-from dnx_gentools.def_enums import *
+from dnx_gentools.def_enums import PROTO, CONN, IPS, ICMP
+from dnx_gentools.def_constants import fast_time, RUN_FOREVER, INSPECT_PACKET, DONT_INSPECT_PACKET
 from dnx_gentools.def_namedtuples import IPS_SCAN_RESULTS, DDOS_TRACKERS, PSCAN_TRACKERS
 from dnx_gentools.standard_tools import inspection_queue
 
@@ -22,19 +22,17 @@ from dnx_secmods.ids_ips.ids_ips_packets import IPSPacket, IPSResponse
 from dnx_secmods.ids_ips.ids_ips_log import Log
 
 __all__ = (
-    'IPS_IDS',
+    'IDS_IPS',
 )
 
-# global to adjust the unique local port count per host before triggering
-PORTSCAN_THRESHOLD = 4
-PREPARE_AND_SEND = IPSResponse.prepare_and_send
 
-
-class IPS_IDS(IPSConfiguration, NFQueue):
+class IDS_IPS(IPSConfiguration, NFQueue):
 
     _packet_parser = IPSPacket.netfilter_recv
 
-    __slots__ = ()
+    __slots__ = (
+        'ddos_queue',
+    )
 
     def __init__(self):
         self.ddos_queue = inspection_queue()
@@ -57,14 +55,14 @@ class IPS_IDS(IPSConfiguration, NFQueue):
         if (packet.src_ip in self.ip_whitelist):
             packet.nfqueue.accept()
 
-            return False
+            return DONT_INSPECT_PACKET
 
         if (self.ddos_enabled):
             # ddos inspection is independent of pscan and does not invoke action on packets
             self.ddos_queue.add(packet)
 
         if (self.pscan_enabled and self.open_ports[packet.protocol]):
-            return True
+            return INSPECT_PACKET
 
         # packet accepted, no inspection
         elif (packet.action is CONN.ACCEPT):
@@ -74,23 +72,30 @@ class IPS_IDS(IPSConfiguration, NFQueue):
         else:
             packet.nfqueue.drop()
 
-        return False
+        return DONT_INSPECT_PACKET
 
     def inspection_worker(self, i: int) -> NoReturn:
         Log.informational(f'[pscan/worker][{i}] inspection thread started')
 
-        for _ in RUN_FOREVER:
-            packet = self.inspection_queue.get()
+        inspection_queue_get = self.inspection_queue.get
+        pre_inspection = self._pre_inspect
 
-            if not self._pre_inspect(packet):
+        for _ in RUN_FOREVER:
+            packet = inspection_queue_get()
+
+            # fast path for certain conditions
+            if not pre_inspection(packet):
                 continue
 
             inspect_portscan(packet)
 
     def ddos_worker(self, i: int) -> NoReturn:
         Log.informational(f'[ddos/worker][{i}] inspection thread started')
+
+        ddos_queue_get = self.ddos_queue.get
+
         for _ in RUN_FOREVER:
-            packet = self.ddos_queue.get()
+            packet = ddos_queue_get()
 
             inspect_ddos(packet)
 
@@ -98,6 +103,11 @@ class IPS_IDS(IPSConfiguration, NFQueue):
 # =================
 # INSPECTION LOGIC
 # =================
+# global to adjust the unique local port count per host before triggering
+PORTSCAN_THRESHOLD = 4
+
+PREPARE_AND_SEND = IPSResponse.prepare_and_send
+
 # conserves resources by not sending packets that don't need to be checked or logged under normal conditions.
 # TODO: ensure trackers are getting cleaned of timed out records at some set interval.
 pscan_tracker: dict[PROTO, PSCAN_TRACKERS] = {
@@ -120,7 +130,6 @@ def inspect_portscan(packet: IPSPacket) -> None:
     # invoking forwarded verdict for connections from hosts that don't meet active scanner criteria
     if (not active_scanner):
 
-        # CONN.INSPECT was dropped in pre_inspect and only needed to inspect for profiling purposes
         if (packet.action is CONN.ACCEPT):
             packet.nfqueue.accept()
 
@@ -133,10 +142,7 @@ def inspect_portscan(packet: IPSPacket) -> None:
 
         return
 
-    # prevents connections from being blocked, but will be logged.
-    # NOTE: this may be noisy and log multiple times per single scan.
-    # TODO: validate.
-    elif (IPS_IDS.ids_mode):
+    elif (IDS_IPS.ids_mode):
         packet.nfqueue.accept()
 
         block_status = IPS.LOGGED
@@ -144,18 +150,13 @@ def inspect_portscan(packet: IPSPacket) -> None:
         Log.debug(f'[pscan/accept] {packet.src_ip}:{packet.src_port} > {packet.dst_ip}:{packet.dst_port}.')
 
     # dropping the packet then checking for further action.
-    elif (IPS_IDS.pscan_enabled):
+    elif (IDS_IPS.pscan_enabled):
 
         packet.nfqueue.drop()
 
         # if rejection is enabled on top of prevention, port unreachable packets will be sent back to the scanner.
-        if (IPS_IDS.pscan_reject):
+        if (IDS_IPS.pscan_reject):
             portscan_reject(pre_detection_logging, packet, initial_block)
-
-        # if initial_block is not set, then the current host has already been effectively blocked and the engine
-        # does not need to log
-        if (not initial_block):
-            return
 
         block_status = get_block_status(pre_detection_logging, packet.protocol)
 
@@ -164,9 +165,12 @@ def inspect_portscan(packet: IPSPacket) -> None:
     # making linter happy
     else: block_status = IPS.DISABLED
 
-    scan_info = IPS_SCAN_RESULTS(initial_block, active_scanner, block_status)
+    # if initial_block is not set, then the current host has already been effectively blocked and the engine
+    # does not need to log
+    if (initial_block):
+        scan_info = IPS_SCAN_RESULTS(initial_block, active_scanner, block_status)
 
-    Log.log(packet, scan_info, engine=IPS.PORTSCAN)
+        Log.log(packet, scan_info, engine=IPS.PORTSCAN)
 
 def portscan_detect(tracker: dict, packet: IPSPacket) -> tuple[bool, bool, dict]:
     '''makes a decision for connections/ packets on whether it matches the profile of a port scanner.
@@ -224,19 +228,19 @@ def portscan_reject(pre_detection_logging: dict, packet: IPSPacket, initial_bloc
 
             # some scanners may send to the same port twice
             for src_port, seq_num in conns:
-                PREPARE_AND_SEND(copy(packet).tcp_override(dst_port, seq_num))  # .tcp_override(dst_port, src_port, # seq_num))
+                PREPARE_AND_SEND(copy(packet).tcp_override(dst_port, seq_num))
 
     elif (packet.protocol is PROTO.UDP):
 
         for ip_header, udp_header in pre_detection_logging.items():
-            PREPARE_AND_SEND(copy(packet).udp_override(ip_header + udp_header))  # .udp_override(ip_header, udp_header))
+            PREPARE_AND_SEND(copy(packet).udp_override(ip_header + udp_header))
 
 # checking intersection between pre detection and open port keys.
 # the missed_port var will contain any port that was scanned before the host was marked as a scanner.
 # if empty, all ports were blocked.
 # NOTE: later, this can be used to report on which specific protocol/port was missed
 def get_block_status(pre_detection_logging: dict, protocol: PROTO) -> IPS:
-    missed_port = pre_detection_logging.keys() & IPS_IDS.open_ports[protocol].keys()
+    missed_port = pre_detection_logging.keys() & IDS_IPS.open_ports[protocol].keys()
     if (missed_port):
         Log.informational(f'[pscan/missed ports] {missed_port}')
 
@@ -250,18 +254,17 @@ def get_block_status(pre_detection_logging: dict, protocol: PROTO) -> IPS:
 def inspect_ddos(packet: IPSPacket) -> None:
     '''drives the overall logic of the ddos detection engine.
     '''
-    # filter to make only icmp echo requests checked.
-    # This used to be done by the IP proxy, but after some optimizations it is much more suited here.
+    # filter out everything but icmp echo requests.
     if (packet.protocol is PROTO.ICMP and packet.icmp_type is not ICMP.ECHO): return
 
     ddos = ddos_tracker[packet.protocol]
     with ddos.lock:
         if not ddos_detected(ddos.tracker, packet): return
 
-    if (IPS_IDS.ids_mode):
+    if (IDS_IPS.ids_mode):
         Log.log(packet, IPS.LOGGED, engine=IPS.DDOS)
 
-    elif (IPS_IDS.ddos_enabled):
+    elif (IDS_IPS.ddos_enabled):
         IPTablesManager.proxy_add_rule(packet.tracked_ip, packet.timestamp, table='raw', chain='IPS')
 
         Log.log(packet, IPS.FILTERED, engine=IPS.DDOS)
@@ -283,8 +286,8 @@ def ddos_detected(tracker: dict, packet: IPSPacket) -> bool:
 
         # this is to suppress log entries for ddos hosts that are being detected by the engine since there is
         # a delay between detection and kernel offload or some packets are already in queue
-        if (packet.tracked_ip not in IPS_IDS.fw_rules):
-            IPS_IDS.fw_rules[packet.tracked_ip] = packet.timestamp
+        if (packet.tracked_ip not in IDS_IPS.fw_rules):
+            IDS_IPS.fw_rules[packet.tracked_ip] = packet.timestamp
 
         return True
 
@@ -301,7 +304,7 @@ def threshold_exceeded(tracked_ip, packet):
 
     Log.debug(f'[ddos/cps] {tracked_ip["count"]/elapsed_time}')
 
-    protocol_src_limit = IPS_IDS.ddos_limits[packet.protocol]
+    protocol_src_limit = IDS_IPS.ddos_limits[packet.protocol]
     if (tracked_ip['count']/elapsed_time < protocol_src_limit):
         return False
 

--- a/dnx_secmods/ids_ips/ids_ips.py
+++ b/dnx_secmods/ids_ips/ids_ips.py
@@ -314,6 +314,8 @@ def threshold_exceeded(tracked_ip, packet):
     return True
 
 def add_to_tracker(tracker, packet, *, engine):
+    Log.debug(f'[{engine}/tracker] host {packet.tracked_ip} added.')
+
     if (engine is IPS.PORTSCAN):
         tracker[packet.tracked_ip] = {
             'last_seen': packet.timestamp, 'active_scanner': False,

--- a/dnx_secmods/ids_ips/ids_ips.py
+++ b/dnx_secmods/ids_ips/ids_ips.py
@@ -37,9 +37,9 @@ class IPS_IDS(IPSConfiguration, NFQueue):
     __slots__ = ()
 
     def __init__(self):
-        super().__init__()
-
         self.ddos_queue = inspection_queue()
+
+        super().__init__()
 
     def _setup(self):
         self.configure()

--- a/dnx_secmods/ids_ips/ids_ips.py
+++ b/dnx_secmods/ids_ips/ids_ips.py
@@ -30,7 +30,7 @@ PORTSCAN_THRESHOLD = 4
 PREPARE_AND_SEND = IPSResponse.prepare_and_send
 
 
-class IPS_IDS(NFQueue, IPSConfiguration):
+class IPS_IDS(IPSConfiguration, NFQueue):
 
     _packet_parser = IPSPacket.netfilter_recv
 

--- a/dnx_secmods/ip_proxy/ip_proxy.py
+++ b/dnx_secmods/ip_proxy/ip_proxy.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
+from threading import Thread
+
 from dnx_gentools.def_typing import *
-from dnx_gentools.def_constants import UINT16_MAX
+from dnx_gentools.def_constants import UINT16_MAX, RUN_FOREVER
 from dnx_gentools.def_enums import CONN, PROTO, Queue, DIR, GEO, REP
 from dnx_gentools.def_namedtuples import IPP_INSPECTION_RESULTS
 
 from dnx_iptools.packet_classes import NFQueue
 
 from ip_proxy_packets import IPPPacket, ProxyResponse
-from ip_proxy_restrict import LanRestrict
+# from ip_proxy_restrict import LanRestrict
 from ip_proxy_automate import ProxyConfiguration
 from ip_proxy_log import Log
 
@@ -22,63 +24,76 @@ REP_LOOKUP: Callable[[int], int] = NotImplemented  # will be assigned by __init_
 PREPARE_AND_SEND = ProxyResponse.prepare_and_send
 
 
-class IPProxy(ProxyConfiguration, NFQueue):
+class IPProxy(NFQueue, ProxyConfiguration):
 
     _packet_parser: ClassVar[ProxyParser] = IPPPacket.netfilter_recv
 
     __slots__ = ()
 
     def _setup(self) -> None:
-        self.__class__.set_proxy_callback(func=inspect)
-
         self.configure()
 
         ProxyResponse.setup(Log, self.__class__.open_ports)
         # LanRestrict.run(self.__class__)
 
-    @staticmethod
-    def forward_packet(packet: IPPPacket, direction: DIR, action: CONN) -> None:
+        for i in range(self.DEFAULT_THREAD_COUNT):
+            Thread(target=self.inspection_worker).start()
 
-        # PRE DROP FILTERS
-        # --------------------
-        # IPS/IDS FORWARD
-        # --------------------
-        # ips filter for only INBOUND traffic inspection.
-        # dropped packets still need to be processed for ddos/portscan profiling
-        # if ips profile is set on a rule for outbound traffic, it will be ignored.
-        # TODO: look into what would be needed to expand ips inspection to lan to wan or lan to lan rules.
-        if (packet.ips_profile and direction is DIR.INBOUND):
-            packet.nfqueue.update_mark(packet.mark & UINT16_MAX)
+    def inspection_worker(self):
+        for _ in RUN_FOREVER:
+            packet = self.inspection_queue.get()
 
-            packet.nfqueue.forward(Queue.IPS_IDS)
+            results = inspect(packet)
 
-        # ====================
-        # IP PROXY DROP
-        # ====================
-        # no other security modules configured on rule and failed ip proxy inspection
-        elif (action is CONN.DROP):
-            packet.nfqueue.drop()
+            forward_packet(packet, packet.direction, results.action)
 
-        # POST DROP FILTERS
-        # --------------------
-        # DNS PROXY FORWARD
-        # --------------------
-        elif (packet.dns_profile and packet.protocol is PROTO.UDP and packet.dst_port == PROTO.DNS):
-            packet.nfqueue.forward(Queue.DNS_PROXY)
+            if (results.action is CONN.REJECT):
+                PREPARE_AND_SEND(packet)
 
-        # ====================
-        # IP PROXY ACCEPT
-        # ====================
-        # no other security modules configured on rule and passed ip proxy inspection
-        elif (action is CONN.ACCEPT):
-            packet.nfqueue.accept()
+            Log.log(packet, results)
+
+# =================
+# FORWARDING LOGIC
+# =================
+def forward_packet(packet: IPPPacket, direction: DIR, action: CONN) -> None:
+    # PRE DROP FILTERS
+    # --------------------
+    # IPS/IDS FORWARD
+    # --------------------
+    # ips filter for only INBOUND traffic inspection.
+    # dropped packets still need to be processed for ddos/portscan profiling
+    # if ips profile is set on a rule for outbound traffic, it will be ignored.
+    # TODO: look into what would be needed to expand ips inspection to lan to wan or lan to lan rules.
+    if (packet.ips_profile and direction is DIR.INBOUND):
+        packet.nfqueue.update_mark(packet.mark & UINT16_MAX)
+
+        packet.nfqueue.forward(Queue.IPS_IDS)
+
+    # ====================
+    # IP PROXY DROP
+    # ====================
+    # no other security modules configured on rule and failed ip proxy inspection
+    elif (action is CONN.DROP):
+        packet.nfqueue.drop()
+
+    # POST DROP FILTERS
+    # --------------------
+    # DNS PROXY FORWARD
+    # --------------------
+    elif (packet.dns_profile and packet.protocol is PROTO.UDP and packet.dst_port == PROTO.DNS):
+        packet.nfqueue.forward(Queue.DNS_PROXY)
+
+    # ====================
+    # IP PROXY ACCEPT
+    # ====================
+    # no other security modules configured on rule and passed ip proxy inspection
+    elif (action is CONN.ACCEPT):
+        packet.nfqueue.accept()
 
 
 # =================
 # INSPECTION LOGIC
 # =================
-FORWARD_PACKET = IPProxy.forward_packet
-
 # direct references to proxy class data structure methods
 _reputation_settings = IPProxy.reputation_settings
 _reputation_enabled  = IPProxy.reputation_enabled
@@ -87,20 +102,7 @@ _geolocation_settings = IPProxy.geolocation_settings
 
 _tor_whitelist = IPProxy.tor_whitelist
 
-def inspect(_, packet: IPPPacket) -> None:
-
-    results = _inspect(packet)
-
-    FORWARD_PACKET(packet, packet.direction, results.action)
-
-    # RECENTLY MOVED: thought it more fitting here than in the forward method
-    # if tcp or udp, we will send a kill conn packet.
-    if (results.action is CONN.REJECT):
-        PREPARE_AND_SEND(packet)
-
-    Log.log(packet, results)
-
-def _inspect(packet: IPPPacket) -> IPP_INSPECTION_RESULTS:
+def inspect(packet: IPPPacket) -> IPP_INSPECTION_RESULTS:
     action = CONN.ACCEPT
     reputation = REP.DNL
 

--- a/dnx_secmods/ip_proxy/ip_proxy.py
+++ b/dnx_secmods/ip_proxy/ip_proxy.py
@@ -37,9 +37,11 @@ class IPProxy(ProxyConfiguration, NFQueue):
         # LanRestrict.run(self.__class__)
 
         for i in range(self.DEFAULT_THREAD_COUNT):
-            Thread(target=self.inspection_worker).start()
+            Thread(target=self.inspection_worker, args=(i,)).start()
 
-    def inspection_worker(self):
+    def inspection_worker(self, i: int) -> NoReturn:
+        Log.informational(f'[proxy/worker][{i}] inspection thread started')
+
         for _ in RUN_FOREVER:
             packet = self.inspection_queue.get()
 

--- a/dnx_secmods/ip_proxy/ip_proxy.py
+++ b/dnx_secmods/ip_proxy/ip_proxy.py
@@ -24,7 +24,7 @@ REP_LOOKUP: Callable[[int], int] = NotImplemented  # will be assigned by __init_
 PREPARE_AND_SEND = ProxyResponse.prepare_and_send
 
 
-class IPProxy(NFQueue, ProxyConfiguration):
+class IPProxy(ProxyConfiguration, NFQueue):
 
     _packet_parser: ClassVar[ProxyParser] = IPPPacket.netfilter_recv
 

--- a/dnx_webui/source/main/dfe_authentication.py
+++ b/dnx_webui/source/main/dfe_authentication.py
@@ -32,7 +32,7 @@ class Authentication:
     this class will access the Flask "request" and "session" data structures directly.
     '''
     def __init__(self):
-        self._time_expired: Event = threading.Event()
+        self._time_expired: Event_T = threading.Event()
 
     @classmethod
     def user_login(cls, *, specify_role: Optional[str] = None) -> tuple:

--- a/dnx_webui/source/web_typing.py
+++ b/dnx_webui/source/web_typing.py
@@ -7,7 +7,10 @@ from typing import TYPE_CHECKING
 if (TYPE_CHECKING):
     from typing import TypeAlias, Type, Any, Callable, ByteString, Optional, Union
 
-    from threading import Lock, Event
+    from threading import Lock as _Lock, Event as _Event
+
+    Lock_T: TypeAlias = _Lock
+    Event_T: TypeAlias = _Event
 
     from werkzeug.datastructures import ImmutableMultiDict, MultiDict
 

--- a/dnx_webui/templates/intrusion/ips.html
+++ b/dnx_webui/templates/intrusion/ips.html
@@ -57,7 +57,7 @@
             </form>
             <div class="row">
               <button class="btn waves-effect waves-light col s4" form="ddos-limits">Update</button>
-              {{ create_switch('Enabled', 'ddos_enabled', checked=ips_settings.enabled)|safe }}
+              {{ create_switch('Enabled', 'ddos_enabled', checked=ips_settings.ddos.enabled)|safe }}
             </div>
           </div>
         </div>

--- a/dnx_webui/templates/main/dashboard.html
+++ b/dnx_webui/templates/main/dashboard.html
@@ -137,7 +137,7 @@
             </div>
             <div class="row">
               <div class="col s8 m4 offset-s2 offset-m4">
-                <a href="/system/reports?view_clients=1" target="_blank">
+                <a href="/system/log/events?view_clients=1" target="_blank">
                   <button class="btn waves-effect waves-light pulse">Open Reports</button>
                 </a>
               </div>

--- a/dnx_webui/templates/rules/firewall/after_firewall.html
+++ b/dnx_webui/templates/rules/firewall/after_firewall.html
@@ -105,8 +105,9 @@ function updateRule() {
 
     col[2].innerHTML = `[*]${ruleEditor.querySelector(".ename").value}`;
 
-    col[9].innerHTML  = ruleEditor.querySelectorAll(".eaction")[0].checked ? "drop" : "accept"
-    col[10].innerHTML = ruleEditor.querySelectorAll(".elog")[0].checked ? "off" : "on"
+    {# eaction[1] is accept radio btn #}
+    col[9].innerHTML  = ruleEditor.querySelectorAll(".eaction")[1].checked ? "accept" : "drop";
+    col[10].innerHTML = ruleEditor.querySelectorAll(".elog")[0].checked ? "on" : "off";
     col[11].innerHTML = ruleEditor.querySelector(".esec1_prof").value;
     col[12].innerHTML = ruleEditor.querySelector(".esec2_prof").value;
     col[13].innerHTML = ruleEditor.querySelector(".esec3_prof").value;

--- a/dnx_webui/templates/rules/firewall/after_firewall.html
+++ b/dnx_webui/templates/rules/firewall/after_firewall.html
@@ -105,8 +105,8 @@ function updateRule() {
 
     col[2].innerHTML = `[*]${ruleEditor.querySelector(".ename").value}`;
 
-    col[9].innerHTML = ruleEditor.querySelectorAll(".eaction")[0].checked ? "drop" : "accept"
-    col[10].innerHTML = ruleEditor.querySelectorAll(".eaction")[0].checked ? "off" : "on"
+    col[9].innerHTML  = ruleEditor.querySelectorAll(".eaction")[0].checked ? "drop" : "accept"
+    col[10].innerHTML = ruleEditor.querySelectorAll(".elog")[0].checked ? "off" : "on"
     col[11].innerHTML = ruleEditor.querySelector(".esec1_prof").value;
     col[12].innerHTML = ruleEditor.querySelector(".esec2_prof").value;
     col[13].innerHTML = ruleEditor.querySelector(".esec3_prof").value;


### PR DESCRIPTION
reimplemented security module inspection callback as semaphore synchronized queues. additional workers can be used by increasing thread count. inspections are 80/20 cpu to io bound so the default its currently set to 4 worker threads for security modules. 

reimplemented server callbacks as an event driven queue. this is single worker thread for request processing, but the servers either require sequential processing or maintain additional queues internally for concurrent or parallel processing.

initial message queue api implemented. this is currently not in use. the above implementation was done in preparation to get to full control of IPC between security module packet inspection. (currently requeues via netfilter's nfqueue mechanism)

bug fixes of various modules
  - webui forms
  - configuration file polling
  - firewall rule editor (log enable)
  - see diff for rest